### PR TITLE
Expose LLM outputs during demo

### DIFF
--- a/agents/recon_agent.py
+++ b/agents/recon_agent.py
@@ -120,6 +120,8 @@ class ReconAgent:
             
             if llm_analysis.success:
                 logger.info("LLM analysis successful - processing findings...")
+                print("\n=== LLM Analysis of Raw Tool Output ===")
+                print(json.dumps(llm_analysis.analysis, indent=2))
                 self._process_llm_analysis(llm_analysis)
             else:
                 logger.warning(f"LLM analysis failed: {llm_analysis.reasoning}")
@@ -262,9 +264,11 @@ class ReconAgent:
             
             # Get LLM prioritization
             llm_prioritization = self.llm_service.prioritize_vulnerabilities(vuln_dicts)
-            
+
             if llm_prioritization.success:
                 logger.info("LLM prioritization successful - applying results...")
+                print("\n=== LLM Vulnerability Prioritization ===")
+                print(json.dumps(llm_prioritization.analysis, indent=2))
                 self._apply_llm_prioritization(all_vulnerabilities, llm_prioritization.analysis)
             else:
                 logger.warning(f"LLM prioritization failed: {llm_prioritization.reasoning}")

--- a/agents/supervisor.py
+++ b/agents/supervisor.py
@@ -6,6 +6,7 @@ Solves Challenge 1: Agent Routing.
 import os
 import sys
 import logging
+import json
 from typing import Optional, List
 from datetime import datetime
 
@@ -147,8 +148,18 @@ class SupervisorAgent:
             # Add all briefs to assessment (they get auto-prioritized)
             for brief in vulnerability_briefs:
                 self.assessment_result.add_vulnerability_brief(brief)
-            
+
             logger.info(f"Identified {len(vulnerability_briefs)} potential vulnerabilities")
+
+            # Demonstrate LLM decision making for next steps
+            decision = self.llm_service.decide_next_scan(
+                [b.to_dict() for b in vulnerability_briefs], self.target_ip
+            )
+            if decision.success:
+                print("\n=== LLM Decision Making ===")
+                print(json.dumps(decision.analysis, indent=2))
+            else:
+                print(f"LLM decision making failed: {decision.reasoning}")
             
             # Step 4: Hand off highest priority vulnerability to ExploitationAgent
             highest_priority = self.assessment_result.get_highest_priority_vuln()
@@ -276,9 +287,11 @@ class SupervisorAgent:
         
         # Use LLM to generate professional report
         llm_report = self.llm_service.generate_report(assessment_data)
-        
+
         if llm_report.success:
             logger.info("LLM report generation successful")
+            print("\n=== LLM Report Generation ===")
+            print(llm_report.analysis.get('report', ''))
             return llm_report.analysis.get('report', self._generate_fallback_report(duration))
         else:
             logger.warning(f"LLM report generation failed: {llm_report.reasoning}")


### PR DESCRIPTION
## Summary
- print analysis from the LLM when recon results are parsed
- show prioritized vulnerability data from the LLM
- display LLM decision-making output in SupervisorAgent
- print the full LLM-generated report

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a0c764c54832fb4fcba0a24183869